### PR TITLE
Fixed one seg fault

### DIFF
--- a/Elijah.cpp
+++ b/Elijah.cpp
@@ -8,6 +8,7 @@ int main()
     Converter *conv = new Converter();
     Tree *x = new Tree;
     stringLinkedList *b;
+    b = conv->ConvertArrToLinkedList(a, 10, true);
     vector<string> vec;
 	string a[10] = {"Kevin","Elijah","Andrew","Elias","Flynn","Callahan","Staple","Ortiz","Calvin", "Stoehr"};
     bool exit=false;
@@ -29,7 +30,7 @@ int main()
         cin>>input;
         if(input==1)
         {
-            b = conv->ConvertArrToLinkedList(a, 10);
+            b = conv->ConvertArrToLinkedList(a, 10, false);
         }
         if(input==2)
         {

--- a/convert.cpp
+++ b/convert.cpp
@@ -12,7 +12,7 @@ Converter::Converter()
 
 Converter::~Converter(){}
 
-stringLinkedList* Converter::ConvertArrToLinkedList(string array[], int size)
+stringLinkedList* Converter::ConvertArrToLinkedList(string array[], int size, bool first)
 {
 	stringLinkedList *head = new stringLinkedList;
 	stringLinkedList *root = new stringLinkedList;
@@ -25,17 +25,19 @@ stringLinkedList* Converter::ConvertArrToLinkedList(string array[], int size)
 		head->next->title = array[i];
 		head = head->next;
 	}
-	cout<<"This is your array"<<endl;
-	for(int i=0; i<size; i++)
-	{
-		cout<<array[i]<<endl;
-	}
-	cout<<"This is your Linked List"<<endl;
-	head = root;
-	while(root->next != NULL)
-	{
-		cout<<root->title<<endl;
-		root = root->next;
+	if(!first){
+        cout<<"This is your array"<<endl;
+        for(int i=0; i<size; i++)
+        {
+            cout<<array[i]<<endl;
+        }
+        cout<<"This is your Linked List"<<endl;
+        head = root;
+        while(root->next != NULL)
+        {
+            cout<<root->title<<endl;
+            root = root->next;
+        }
 	}
 	return head;
 }

--- a/convert.h
+++ b/convert.h
@@ -39,7 +39,7 @@ class Converter{
 	public:
 		Converter();
 		~Converter();
-		stringLinkedList* ConvertArrToLinkedList(string array[], int size);
+		stringLinkedList* ConvertArrToLinkedList(string array[], int size, bool first);
 		string* ConvertLLToArray(stringLinkedList* root);
 		vector<string> ConvertLLToVector(stringLinkedList* root);
 		vector<string> arrayToVector(string str[], int size);


### PR DESCRIPTION
If the user does not choose the menu in order, it seg faults if 2 or 3 is done before one because b is still an empty linked list, so I fixed this issue by defining b before and making sure it does not print everything out unless the user picks 1. It still seg faults if the user chooses 5 or 6 before 4.
